### PR TITLE
CHANGE(grafana): Provision new dashboards for 19.04 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ None
 Role Variables
 --------------
 
-| Variable name   | Description                                   | Type    |
-| --------------- | --------------------------------------------- | ------- |
-| grafana_version | Version of grafana to use                     | String  |
-| grafana_paths   | Configuration paths used by grafana-server    | Object  |
-| grafana_http    | Host/Port on which grafana listens            | Object  |
-| grafana_auth    | Grafana credentials                           | Object  |
-| grafana_thene   | Theme (dark or light) used by grafana         | String  |
-| prometheus_host | Host on which prometheus source is configured | String  |
-| prometheus_port | Port on which prometheus source is configured | Integer |
+| Variable name         | Description                                   | Type    |
+| --------------------- | --------------------------------------------- | ------- |
+| grafana_version       | Version of grafana to use                     | String  |
+| grafana_paths         | Configuration paths used by grafana-server    | Object  |
+| grafana_http          | Host/Port on which grafana listens            | Object  |
+| grafana_auth          | Grafana credentials                           | Object  |
+| grafana_thene         | Theme (dark or light) used by grafana         | String  |
+| grafana_oiofs_enabled | Provision dashboard for filesystem connector  | String  |
+| prometheus_host       | Host on which prometheus source is configured | String  |
+| prometheus_port       | Port on which prometheus source is configured | Integer |
 
 
 Tools - Dashboard retriever

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ grafana_theme: light
 prometheus_host: localhost
 prometheus_port: 9090
 
+grafana_oiofs_enabled: false
+
 grafana_dashboards:
   - overview
   - openio_services
@@ -37,4 +39,5 @@ grafana_dashboards:
   - system
   - health
   - software_version_info
+  - diagnostics
 ...

--- a/files/diagnostics.json
+++ b/files/diagnostics.json
@@ -1,0 +1,258 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1552656999545,
+  "links": [],
+  "panels": [
+    {
+      "content": "This dashboard can be expanded with graphs to provide more insight during a particular incident.\n",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "links": [],
+      "mode": "markdown",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(label_replace(netdata_web_log_response_time_milliseconds_average{instance=~\"[[host]]\", dimension=\"avg\", chart=~\".*rawx.*\"}, 'chart2', '$1', 'chart', '.*rawx\\\\.(.*).log.*')) by (chart2)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{chart2}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Response time by RAWX instance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(aggr:netdata_web_log_response_codes:sum{chart2=~\".*.meta2\",dimension=~\"5xx\", instance=~\"[[host]]\"}) by (instance)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Meta2 errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": "label_values(netdata_system_cpu_percentage_average, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Diagnostics"
+}

--- a/files/filesystem_connector.json
+++ b/files/filesystem_connector.json
@@ -1,0 +1,1095 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1552561821409,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#ea6460",
+        "rgba(237, 129, 40, 0.89)",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "0",
+          "text": "ERROR",
+          "to": "99.99999"
+        },
+        {
+          "from": "100",
+          "text": "OK",
+          "to": "100"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (sum(probe_success{service=\"oiofs\"} == 1) / count(probe_success{service=\"oiofs\"}) or vector(1))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "100,99",
+      "title": "Status",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "OK",
+          "value": "100"
+        },
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "#65c5db",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 21,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(probe_success{service=\"oiofs\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Instances",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "content": "### Cache",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 16,
+      "links": [],
+      "mode": "markdown",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(rate(netdata_oiofs_cache_ops_average{instance=~\"[[host]]\"}[5m]), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{chart2}} - {{dimension}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cache ops",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(netdata_oiofs_cache_chunks_average{instance=~\"[[host]]\"}, \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{chart2}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cache chunks",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "pps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(netdata_oiofs_cache_latency_us_average{instance=~\"[[host]]\"}, \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{chart2}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cache latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "\u00b5s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(netdata_oiofs_cache_age_us_average{instance=~\"[[host]]\"}, \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{chart2}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cache age",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "\u00b5s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(netdata_oiofs_cache_size_bytes_average{instance=~\"[[host]]\", dimension!~\"read\"}, \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}} - {{chart2}} - {{dimension}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cache usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(rate(netdata_oiofs_cache_size_bytes_average{instance=~\"[[host]]\", dimension=\"read\"}[5m]), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}} - {{chart2}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cache read rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "content": "### Data",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 17,
+      "links": [],
+      "mode": "markdown",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(sum(rate(netdata_oiofs_sds_bytes_average{instance=~\"[[host]]\"}[5m])) by (instance, chart, dimension), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{dimension}} - {{instance}} - {{chart2}} ",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SDS data rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(sum(rate(netdata_oiofs_fuse_bytes_average{instance=~\"[[host]]\"}[5m])) by (instance, chart, dimension), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{dimension}} - {{instance}} - {{chart2}} ",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Fuse I/O",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(sum(rate(netdata_oiofs_sds_dl_ops_average{instance=~\"[[host]]\"}[5m])) by (instance, chart), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "download - {{instance}} - {{chart2}} ",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(sum(rate(netdata_oiofs_sds_ul_ops_average{instance=~\"[[host]]\"}[5m])) by (instance, chart), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "upload - {{instance}} - {{chart2}} ",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SDS ops",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(sum(rate(netdata_oiofs_sds_dl_ops_average{instance=~\"[[host]]\", dimension=\"failed\"}[5m])) by (instance, chart), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "download - {{instance}} - {{chart2}} ",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(sum(rate(netdata_oiofs_sds_ul_ops_average{instance=~\"[[host]]\", dimension=\"failed\"}[5m])) by (instance, chart), \"chart2\", \"$1\", \"chart\", \"oiofs_(.*)\\\\..*\")",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "upload - {{instance}} - {{chart2}} ",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SDS errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": "label_values(netdata_system_cpu_percentage_average, instance)",
+        "refresh": 1,
+        "regex": "/.*/",
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Filesystem connector"
+}

--- a/files/health.json
+++ b/files/health.json
@@ -15,35 +15,205 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1541517174111,
+  "iteration": 1552499282784,
   "links": [],
   "panels": [
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
+      "colorBackground": true,
+      "colorValue": false,
       "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
+        "#f29191",
+        "#f29191",
+        "#9ac48a"
       ],
       "datasource": null,
-      "decimals": null,
+      "description": "Indicates the current health of the monitoring system. Errors correspond to netdata/blackbox targets that are down",
       "format": "percent",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
-        "show": true,
+        "show": false,
         "thresholdLabels": false,
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 6,
-        "w": 5,
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 213,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "100",
+          "text": "OK",
+          "to": "100"
+        },
+        {
+          "from": "0",
+          "text": "ERROR",
+          "to": "99"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * count(up{module=~\"netdata|blackbox\"} == 1) / count(up{module=~\"netdata|blackbox\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "99,100",
+      "title": "Collection status",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "OK",
+          "value": "100"
+        },
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#badff4",
+        "#65c5db",
+        "#5195ce"
+      ],
+      "datasource": null,
+      "description": "",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
         "x": 3,
         "y": 0
       },
-      "id": 109,
+      "id": 226,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(up{module=\"netdata\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0",
+      "title": "Instances",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "OK",
+          "value": "100"
+        },
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f9ba8f",
+        "rgba(237, 129, 40, 0.89)",
+        "#65c5db"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "id": 118,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -71,26 +241,27 @@
           "to": "null"
         }
       ],
+      "repeatDirection": "h",
       "sparkline": {
-        "fillColor": "rgb(240, 240, 240)",
-        "full": true,
-        "lineColor": "#65c5db",
-        "show": true
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
       },
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * count(probe_success == 1) / count(probe_success)",
+          "expr": "count(probe_success)",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
           "refId": "A"
         }
       ],
-      "thresholds": "50,80",
-      "title": "Cluster health",
-      "transparent": false,
+      "thresholds": "0,0",
+      "title": "Checks",
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "120%",
       "valueMaps": [
         {
           "op": "=",
@@ -119,12 +290,12 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 8,
+        "h": 4,
+        "w": 3,
+        "x": 9,
         "y": 0
       },
-      "id": 118,
+      "id": 214,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -170,9 +341,9 @@
         }
       ],
       "thresholds": "0,0",
-      "title": "Passed checks",
+      "title": "Passed",
       "type": "singlestat",
-      "valueFontSize": "200%",
+      "valueFontSize": "120%",
       "valueMaps": [
         {
           "op": "=",
@@ -201,8 +372,8 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
+        "h": 4,
+        "w": 3,
         "x": 12,
         "y": 0
       },
@@ -252,9 +423,9 @@
         }
       ],
       "thresholds": "1,1",
-      "title": "Failed checks",
+      "title": "Failed",
       "type": "singlestat",
-      "valueFontSize": "200%",
+      "valueFontSize": "120%",
       "valueMaps": [],
       "valueName": "current"
     },
@@ -277,9 +448,9 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
+        "h": 4,
+        "w": 3,
+        "x": 15,
         "y": 0
       },
       "id": 206,
@@ -319,7 +490,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(ALERTS) OR vector(0)",
+          "expr": "count(ALERTS{alertstate=\"firing\"}) OR vector(0)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -330,8 +501,169 @@
       "thresholds": "1,1",
       "title": "Active alerts",
       "type": "singlestat",
-      "valueFontSize": "200%",
+      "valueFontSize": "120%",
       "valueMaps": [],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f29191",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "description": "",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 0
+      },
+      "id": 224,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * count(up{module=\"netdata\"} == 1) / count(up{module=\"netdata\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "99,100",
+      "title": "Netdata",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "OK",
+          "value": "100"
+        },
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f29191",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "description": "",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 225,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * count(up{module=\"blackbox\"} == 1) / count(up{module=\"blackbox\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "99,100",
+      "title": "Blackbox",
+      "type": "singlestat",
+      "valueFontSize": "120%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "OK",
+          "value": "100"
+        },
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
       "valueName": "current"
     },
     {
@@ -340,11 +672,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 4
       },
-      "id": 120,
+      "id": 268,
       "panels": [],
-      "title": "Health",
+      "title": "Services",
       "type": "row"
     },
     {
@@ -367,9 +699,9 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
+        "w": 3,
         "x": 0,
-        "y": 7
+        "y": 5
       },
       "id": 123,
       "interval": null,
@@ -386,7 +718,7 @@
         }
       ],
       "maxDataPoints": 100,
-      "minSpan": 2,
+      "minSpan": 3,
       "nullPointMode": "connected",
       "nullText": null,
       "postfix": "",
@@ -399,8 +731,8 @@
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "meta0",
-          "value": "meta0"
+          "text": "conscience",
+          "value": "conscience"
         }
       },
       "sparkline": {
@@ -412,7 +744,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"})",
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -453,11 +785,11 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 7
+        "w": 3,
+        "x": 3,
+        "y": 5
       },
-      "id": 207,
+      "id": 269,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -472,7 +804,7 @@
         }
       ],
       "maxDataPoints": 100,
-      "minSpan": 2,
+      "minSpan": 3,
       "nullPointMode": "connected",
       "nullText": null,
       "postfix": "",
@@ -482,7 +814,95 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1541517174111,
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "zookeeper",
+          "value": "zookeeper"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 5
+      },
+      "id": 270,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
@@ -500,7 +920,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"})",
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -541,11 +961,11 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 7
+        "w": 3,
+        "x": 9,
+        "y": 5
       },
-      "id": 208,
+      "id": 271,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -560,7 +980,7 @@
         }
       ],
       "maxDataPoints": 100,
-      "minSpan": 2,
+      "minSpan": 3,
       "nullPointMode": "connected",
       "nullText": null,
       "postfix": "",
@@ -570,7 +990,359 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1541517174111,
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "oioswift",
+          "value": "oioswift"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 5
+      },
+      "id": 272,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "account",
+          "value": "account"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 5
+      },
+      "id": 273,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "redis",
+          "value": "redis"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 18,
+        "y": 5
+      },
+      "id": 274,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "redissentinel",
+          "value": "redissentinel"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 5
+      },
+      "id": 275,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
@@ -588,7 +1360,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"})",
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -629,11 +1401,11 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 7
+        "w": 3,
+        "x": 0,
+        "y": 8
       },
-      "id": 209,
+      "id": 276,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -648,7 +1420,7 @@
         }
       ],
       "maxDataPoints": 100,
-      "minSpan": 2,
+      "minSpan": 3,
       "nullPointMode": "connected",
       "nullText": null,
       "postfix": "",
@@ -658,183 +1430,7 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1541517174111,
-      "repeatPanelId": 123,
-      "scopedVars": {
-        "service": {
-          "selected": false,
-          "text": "meta2",
-          "value": "meta2"
-        }
-      },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"})",
-          "format": "time_series",
-          "instant": true,
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "50,100",
-      "title": "[[service]]",
-      "transparent": false,
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "?",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "#f29191",
-        "#f2c96d",
-        "#9ac48a"
-      ],
-      "datasource": null,
-      "format": "percent",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 7
-      },
-      "id": 210,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "minSpan": 2,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [],
-      "repeat": null,
-      "repeatDirection": "h",
-      "repeatIteration": 1541517174111,
-      "repeatPanelId": 123,
-      "scopedVars": {
-        "service": {
-          "selected": false,
-          "text": "conscience",
-          "value": "conscience"
-        }
-      },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"})",
-          "format": "time_series",
-          "instant": true,
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "50,100",
-      "title": "[[service]]",
-      "transparent": false,
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "?",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "#f29191",
-        "#f2c96d",
-        "#9ac48a"
-      ],
-      "datasource": null,
-      "format": "percent",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 7
-      },
-      "id": 211,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "minSpan": 2,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [],
-      "repeat": null,
-      "repeatDirection": "h",
-      "repeatIteration": 1541517174111,
+      "repeatIteration": 1552499282784,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
@@ -852,7 +1448,359 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\", host=~\"[[host]]\"})",
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 8
+      },
+      "id": 277,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "meta2",
+          "value": "meta2"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 8
+      },
+      "id": 278,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "rawx",
+          "value": "rawx"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 8
+      },
+      "id": 279,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "rdir",
+          "value": "rdir"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 8
+      },
+      "id": 280,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1552499282784,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "meta0",
+          "value": "meta0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -879,11 +1827,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
-      "id": 192,
+      "id": 240,
       "panels": [],
-      "title": "Alerts",
+      "title": "Details",
       "type": "row"
     },
     {
@@ -891,10 +1839,10 @@
       "datasource": null,
       "fontSize": "100%",
       "gridPos": {
-        "h": 17,
-        "w": 12,
+        "h": 15,
+        "w": 9,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 133,
       "links": [],
@@ -986,6 +1934,36 @@
           "thresholds": [],
           "type": "hidden",
           "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Value #A",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Value #B",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
         }
       ],
       "targets": [
@@ -995,6 +1973,13 @@
           "instant": true,
           "intervalFactor": 1,
           "refId": "A"
+        },
+        {
+          "expr": "up{module=~\"netdata|blackbox\"} == 0",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "B"
         }
       ],
       "title": "Failed checks",
@@ -1006,10 +1991,10 @@
       "datasource": null,
       "fontSize": "100%",
       "gridPos": {
-        "h": 17,
-        "w": 12,
-        "x": 12,
-        "y": 11
+        "h": 15,
+        "w": 15,
+        "x": 9,
+        "y": 12
       },
       "id": 177,
       "links": [],
@@ -1167,7 +2152,7 @@
       ],
       "targets": [
         {
-          "expr": "ALERTS",
+          "expr": "ALERTS{alertstate=\"firing\"}",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1186,30 +2171,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "datasource": "prometheus",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": true,
-        "name": "host",
-        "options": [],
-        "query": "label_values(probe_success, host)",
-        "refresh": 1,
-        "regex": "/.*/",
-        "sort": 2,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
         "allValue": "blank=All",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
         "datasource": "prometheus",
         "hide": 2,
         "includeAll": true,
@@ -1253,7 +2215,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {

--- a/files/network.json
+++ b/files/network.json
@@ -16,7 +16,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1530202832325,
+  "iteration": 1552580677541,
   "links": [],
   "panels": [
     {
@@ -164,7 +164,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -556,7 +556,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -565,7 +565,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -705,7 +705,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -714,7 +714,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -832,7 +832,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -841,7 +841,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -966,7 +966,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -975,7 +975,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1093,7 +1093,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1102,7 +1102,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1220,7 +1220,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1229,7 +1229,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1353,7 +1353,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1362,12 +1362,12 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     }
   ],
-  "refresh": "10s",
+  "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -1395,8 +1395,8 @@
     ]
   },
   "time": {
-    "from": "now-30m",
-    "to": "now"
+    "from": "2019-03-12T14:07:28.761Z",
+    "to": "2019-03-12T14:07:39.763Z"
   },
   "timepicker": {
     "hidden": false,

--- a/files/openio_services.json
+++ b/files/openio_services.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1542204282606,
+  "iteration": 1552579991533,
   "links": [],
   "panels": [
     {
@@ -184,69 +184,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "alias": "$tag_namespace: $tag_service_type",
-          "dsType": "influxdb",
-          "expr": "avg(label_replace(netdata_openio_score__average{chart=\"openio.score\",family=\"Score\",instance=~\"[[host]]\"}, \"dim2\", \"$1\", \"dimension\", \"(.*?)[_].*\")) by (dim2)",
-          "format": "time_series",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "service_type"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "namespace"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "intervalFactor": 1,
-          "legendFormat": "{{dim2}}",
-          "measurement": "openio_score",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"[[DS]]\".\"openio_score\" WHERE \"namespace\" =~ /^$namespace$/ AND \"host\" =~ /^$host$/ AND $timeFilter GROUP BY time([[ds_int]]), \"service_type\", \"namespace\" fill(null)",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "host",
-              "operator": "=~",
-              "value": "/^$host$/"
-            }
-          ]
-        },
-        {
           "expr": "aggr:netdata_openio_score:avg_per_service",
           "format": "time_series",
           "hide": false,
@@ -287,7 +224,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -366,6 +303,7 @@
         "show": true,
         "showHistogram": false
       },
+      "transparent": false,
       "type": "heatmap",
       "xAxis": {
         "show": true
@@ -376,8 +314,8 @@
         "decimals": null,
         "format": "short",
         "logBase": 1,
-        "max": null,
-        "min": null,
+        "max": "120",
+        "min": "0",
         "show": true,
         "splitFactor": null
       },
@@ -743,7 +681,7 @@
         "#d44a3a"
       ],
       "datasource": "prometheus",
-      "format": "none",
+      "format": "short",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -967,7 +905,7 @@
         "#d44a3a"
       ],
       "datasource": "prometheus",
-      "format": "none",
+      "format": "short",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -1149,7 +1087,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1229,7 +1167,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1243,12 +1181,193 @@
       ]
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 127,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(netdata_openio_meta2_cache_bases_cold__average{instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "cold",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(netdata_openio_meta2_cache_bases_max__average{instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "max",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Meta2 cache bases",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 129,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(netdata_openio_meta2_elections_total__average{instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(netdata_openio_meta2_elections_failed__average{instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "failed",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(netdata_openio_meta2_elections_none__average{instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "none",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Meta2 elections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ]
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 45
       },
       "id": 113,
       "panels": [],
@@ -1277,7 +1396,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 37
+        "y": 46
       },
       "id": 95,
       "interval": null,
@@ -1316,7 +1435,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\"}) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\"})",
+          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\", chart2=~\".*.oioswift\"}) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\", chart2=~\".*.oioswift\"})",
           "format": "time_series",
           "groupBy": [
             {
@@ -1379,7 +1498,7 @@
         "h": 8,
         "w": 18,
         "x": 6,
-        "y": 37
+        "y": 46
       },
       "id": 44,
       "legend": {
@@ -1494,7 +1613,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1530,7 +1649,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 45
+        "y": 54
       },
       "id": 91,
       "interval": null,
@@ -1631,7 +1750,7 @@
         "h": 7,
         "w": 9,
         "x": 6,
-        "y": 45
+        "y": 54
       },
       "id": 46,
       "legend": {
@@ -1663,7 +1782,7 @@
         {
           "alias": "$tag_namespace: $tag_servicetype: $tag_type",
           "dsType": "influxdb",
-          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", chart2=~\".*.oioswift\", instance=~\"[[host]]\"}) by (chart2, dimension)",
+          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{chart2=~\".*.oioswift\", instance=~\"[[host]]\"}) by (chart2, dimension)",
           "format": "time_series",
           "groupBy": [
             {
@@ -1746,7 +1865,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1770,7 +1889,7 @@
         "h": 7,
         "w": 9,
         "x": 15,
-        "y": 45
+        "y": 54
       },
       "id": 49,
       "legend": {
@@ -1830,7 +1949,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1854,7 +1973,7 @@
         "h": 7,
         "w": 9,
         "x": 6,
-        "y": 52
+        "y": 61
       },
       "id": 45,
       "legend": {
@@ -1970,7 +2089,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1994,7 +2113,7 @@
         "h": 7,
         "w": 9,
         "x": 15,
-        "y": 52
+        "y": 61
       },
       "id": 47,
       "legend": {
@@ -2109,7 +2228,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2128,7 +2247,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 68
       },
       "id": 115,
       "panels": [],
@@ -2145,7 +2264,7 @@
         "#d44a3a"
       ],
       "datasource": "prometheus",
-      "format": "none",
+      "format": "short",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -2157,7 +2276,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 60
+        "y": 69
       },
       "id": 107,
       "interval": null,
@@ -2227,7 +2346,7 @@
         "h": 8,
         "w": 9,
         "x": 6,
-        "y": 60
+        "y": 69
       },
       "id": 71,
       "legend": {
@@ -2315,7 +2434,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2339,7 +2458,7 @@
         "h": 8,
         "w": 9,
         "x": 15,
-        "y": 60
+        "y": 69
       },
       "id": 67,
       "legend": {
@@ -2427,7 +2546,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2462,7 +2581,7 @@
         "h": 9,
         "w": 6,
         "x": 0,
-        "y": 68
+        "y": 77
       },
       "id": 93,
       "interval": null,
@@ -2563,7 +2682,7 @@
         "h": 9,
         "w": 9,
         "x": 6,
-        "y": 68
+        "y": 77
       },
       "id": 103,
       "legend": {
@@ -2619,7 +2738,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2643,7 +2762,7 @@
         "h": 9,
         "w": 9,
         "x": 15,
-        "y": 68
+        "y": 77
       },
       "id": 105,
       "legend": {
@@ -2699,7 +2818,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2718,7 +2837,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 77
+        "y": 86
       },
       "id": 117,
       "panels": [],
@@ -2736,7 +2855,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 78
+        "y": 87
       },
       "id": 38,
       "legend": {
@@ -2838,14 +2957,6 @@
               "value": "/^current.*/"
             }
           ]
-        },
-        {
-          "expr": "sum(netdata_beanstalk_current_jobs_jobs_average{instance=~\"[[host]]\"}) by (dimension)",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
-          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -2871,7 +2982,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2895,7 +3006,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 78
+        "y": 87
       },
       "id": 39,
       "legend": {
@@ -3035,7 +3146,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3054,7 +3165,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 95
       },
       "id": 119,
       "panels": [],
@@ -3072,7 +3183,7 @@
         "h": 8,
         "w": 16,
         "x": 0,
-        "y": 87
+        "y": 96
       },
       "id": 41,
       "legend": {
@@ -3181,7 +3292,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3205,7 +3316,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 87
+        "y": 96
       },
       "id": 43,
       "legend": {
@@ -3314,7 +3425,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3338,7 +3449,7 @@
         "h": 8,
         "w": 16,
         "x": 0,
-        "y": 95
+        "y": 104
       },
       "id": 40,
       "legend": {
@@ -3444,7 +3555,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3468,7 +3579,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 95
+        "y": 104
       },
       "id": 42,
       "legend": {
@@ -3574,7 +3685,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3616,7 +3727,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {

--- a/files/openio_system.json
+++ b/files/openio_system.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1541517206075,
+  "iteration": 1552580662739,
   "links": [],
   "panels": [
     {
@@ -61,7 +61,7 @@
         {
           "alias": "$tag_servicetype: $tag_mode",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_cpu_system_cpu_time___average{chart=\"apps.cpu_system\",family=\"cpu\",instance=~\"[[host]]\"}) by (dimension)",
+          "expr": "100 * netdata_apps_cpu_system_cpu_time___average{chart=\"apps.cpu_system\",family=\"cpu\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -90,7 +90,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
+          "legendFormat": "{{instance}} {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -206,7 +206,7 @@
         {
           "alias": "$tag_servicetype: $tag_type",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_preads_kilobytes_persec_average{chart=\"apps.preads\",family=\"disk\",instance=~\"[[host]]\"}) by (dimension)",
+          "expr": "netdata_apps_preads_kilobytes_persec_average{chart=\"apps.preads\",family=\"disk\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -235,7 +235,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "reads - {{dimension}}",
+          "legendFormat": "reads - {{instance}} - {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -274,7 +274,7 @@
         {
           "alias": "$tag_servicetype: $tag_type",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_pwrites_kilobytes_persec_average{chart=\"apps.pwrites\",family=\"disk\",instance=~\"[[host]]\"}) by (dimension)",
+          "expr": "netdata_apps_pwrites_kilobytes_persec_average{chart=\"apps.pwrites\",family=\"disk\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -303,7 +303,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "writes - {{dimension}}",
+          "legendFormat": "writes - {{instance}} - {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -363,7 +363,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -419,7 +419,7 @@
         {
           "alias": "$tag_servicetype",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_files_open_files_average{chart=\"apps.files\",family=\"disk\",instance=~\"[[host]]\"}) by (dimension)\n",
+          "expr": "netdata_apps_files_open_files_average{chart=\"apps.files\",family=\"disk\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -442,7 +442,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
+          "legendFormat": "{{instance}} {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -496,7 +496,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -552,7 +552,7 @@
         {
           "alias": "$tag_servicetype",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_mem_MB_average{chart=\"apps.mem\",family=\"mem\",instance=~\"[[host]]\"}) by (dimension)\n",
+          "expr": "netdata_apps_mem_MB_average{chart=\"apps.mem\",family=\"mem\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -575,7 +575,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
+          "legendFormat": "{{instance}} {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -629,7 +629,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -648,6 +648,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "decimals": null,
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -685,7 +686,7 @@
         {
           "alias": "$tag_servicetype",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_processes_processes_average{chart=\"apps.processes\",family=\"processes\",instance=~\"[[host]]\"}) by (dimension)",
+          "expr": "netdata_apps_processes_processes_average{chart=\"apps.processes\",family=\"processes\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -708,7 +709,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
+          "legendFormat": "{{instance}} {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -758,11 +759,12 @@
       },
       "yaxes": [
         {
-          "format": "short",
-          "label": null,
+          "decimals": 0,
+          "format": "none",
+          "label": "",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -771,7 +773,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -818,7 +820,7 @@
         {
           "alias": "$tag_servicetype",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_threads_threads_average{chart=\"apps.threads\",family=\"processes\",instance=~\"[[host]]\"}) by (dimension)",
+          "expr": "netdata_apps_threads_threads_average{chart=\"apps.threads\",family=\"processes\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -841,7 +843,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
+          "legendFormat": "{{instance}} {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -895,7 +897,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -951,7 +953,7 @@
         {
           "alias": "$tag_servicetype",
           "dsType": "influxdb",
-          "expr": "sum(netdata_apps_sockets_open_sockets_average{chart=\"apps.sockets\",family=\"net\",instance=~\"[[host]]\"}) by (dimension)",
+          "expr": "netdata_apps_sockets_open_sockets_average{chart=\"apps.sockets\",family=\"net\",instance=~\"[[host]]\", dimension=~\"[[service]]\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -974,7 +976,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
+          "legendFormat": "{{instance}} {{dimension}}",
           "measurement": "openio",
           "orderByTime": "ASC",
           "policy": "default",
@@ -1028,87 +1030,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 21
-      },
-      "id": 35,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "netdata_apps_sockets_open_sockets_average{instance=~'[[host]]', dimension='openio.meta2'}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{dimension}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Opened Sockets (META2)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1141,6 +1063,223 @@
         "refresh": 1,
         "regex": "/.*/",
         "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "openio.meta2",
+          "value": [
+            "openio.meta2"
+          ]
+        },
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "service",
+        "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "apps.plugin",
+            "value": "apps.plugin"
+          },
+          {
+            "selected": false,
+            "text": "cron",
+            "value": "cron"
+          },
+          {
+            "selected": false,
+            "text": "email",
+            "value": "email"
+          },
+          {
+            "selected": false,
+            "text": "haproxy",
+            "value": "haproxy"
+          },
+          {
+            "selected": false,
+            "text": "httpd",
+            "value": "httpd"
+          },
+          {
+            "selected": false,
+            "text": "java",
+            "value": "java"
+          },
+          {
+            "selected": false,
+            "text": "keepalived",
+            "value": "keepalived"
+          },
+          {
+            "selected": false,
+            "text": "kernel",
+            "value": "kernel"
+          },
+          {
+            "selected": false,
+            "text": "ksmd",
+            "value": "ksmd"
+          },
+          {
+            "selected": false,
+            "text": "logs",
+            "value": "logs"
+          },
+          {
+            "selected": false,
+            "text": "mysqld",
+            "value": "mysqld"
+          },
+          {
+            "selected": false,
+            "text": "netdata",
+            "value": "netdata"
+          },
+          {
+            "selected": false,
+            "text": "nfs",
+            "value": "nfs"
+          },
+          {
+            "selected": false,
+            "text": "nosql",
+            "value": "nosql"
+          },
+          {
+            "selected": false,
+            "text": "openio-keystone",
+            "value": "openio-keystone"
+          },
+          {
+            "selected": false,
+            "text": "openio.account",
+            "value": "openio.account"
+          },
+          {
+            "selected": false,
+            "text": "openio.beanstalkd",
+            "value": "openio.beanstalkd"
+          },
+          {
+            "selected": false,
+            "text": "openio.blob-indexer",
+            "value": "openio.blob-indexer"
+          },
+          {
+            "selected": false,
+            "text": "openio.conscience",
+            "value": "openio.conscience"
+          },
+          {
+            "selected": false,
+            "text": "openio.conscienceagent",
+            "value": "openio.conscienceagent"
+          },
+          {
+            "selected": false,
+            "text": "openio.event-agent",
+            "value": "openio.event-agent"
+          },
+          {
+            "selected": false,
+            "text": "openio.meta0",
+            "value": "openio.meta0"
+          },
+          {
+            "selected": false,
+            "text": "openio.meta1",
+            "value": "openio.meta1"
+          },
+          {
+            "selected": true,
+            "text": "openio.meta2",
+            "value": "openio.meta2"
+          },
+          {
+            "selected": false,
+            "text": "openio.oio-proxy",
+            "value": "openio.oio-proxy"
+          },
+          {
+            "selected": false,
+            "text": "openio.rawx",
+            "value": "openio.rawx"
+          },
+          {
+            "selected": false,
+            "text": "openio.rdir",
+            "value": "openio.rdir"
+          },
+          {
+            "selected": false,
+            "text": "openio.redis",
+            "value": "openio.redis"
+          },
+          {
+            "selected": false,
+            "text": "openio.swift-proxy",
+            "value": "openio.swift-proxy"
+          },
+          {
+            "selected": false,
+            "text": "openio.zookeeper",
+            "value": "openio.zookeeper"
+          },
+          {
+            "selected": false,
+            "text": "other",
+            "value": "other"
+          },
+          {
+            "selected": false,
+            "text": "python.d.plugin",
+            "value": "python.d.plugin"
+          },
+          {
+            "selected": false,
+            "text": "sql",
+            "value": "sql"
+          },
+          {
+            "selected": false,
+            "text": "ssh",
+            "value": "ssh"
+          },
+          {
+            "selected": false,
+            "text": "system",
+            "value": "system"
+          },
+          {
+            "selected": false,
+            "text": "tc-qos-helper",
+            "value": "tc-qos-helper"
+          },
+          {
+            "selected": false,
+            "text": "timedb",
+            "value": "timedb"
+          }
+        ],
+        "query": "label_values(netdata_apps_cpu_system_cpu_time___average, dimension)",
+        "refresh": 0,
+        "regex": "",
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/files/overview.json
+++ b/files/overview.json
@@ -15,54 +15,8 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1541517159028,
   "links": [],
   "panels": [
-    {
-      "content": "### Health",
-      "gridPos": {
-        "h": 2,
-        "w": 4,
-        "x": 0,
-        "y": 0
-      },
-      "id": 137,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "content": "### System",
-      "gridPos": {
-        "h": 2,
-        "w": 12,
-        "x": 5,
-        "y": 0
-      },
-      "id": 136,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "content": "### Network",
-      "gridPos": {
-        "h": 2,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 140,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
     {
       "cacheTimeout": null,
       "colorBackground": true,
@@ -70,7 +24,7 @@
       "colors": [
         "#9ac48a",
         "rgba(237, 129, 40, 0.89)",
-        "#f29191"
+        "#eab839"
       ],
       "datasource": null,
       "format": "none",
@@ -85,7 +39,7 @@
         "h": 3,
         "w": 2,
         "x": 0,
-        "y": 2
+        "y": 0
       },
       "id": 128,
       "interval": null,
@@ -168,7 +122,7 @@
         "h": 3,
         "w": 2,
         "x": 2,
-        "y": 2
+        "y": 0
       },
       "id": 131,
       "interval": null,
@@ -214,7 +168,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(ALERTS) OR vector(0)",
+          "expr": "count(ALERTS{alertstate=\"firing\"}) OR vector(0)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -251,7 +205,7 @@
         "h": 4,
         "w": 3,
         "x": 5,
-        "y": 2
+        "y": 0
       },
       "id": 10,
       "interval": null,
@@ -291,7 +245,7 @@
       "targets": [
         {
           "dsType": "influxdb",
-          "expr": "avg(netdata_system_cpu_percentage_average{chart=\"system.cpu\",family=\"cpu\",dimension=\"user\",instance=~\"[[host]]\"})",
+          "expr": "avg(netdata_system_cpu_percentage_average{chart=\"system.cpu\",family=\"cpu\",dimension=\"user\"})",
           "format": "time_series",
           "groupBy": [
             {
@@ -383,7 +337,7 @@
         "h": 4,
         "w": 3,
         "x": 8,
-        "y": 2
+        "y": 0
       },
       "id": 11,
       "interval": null,
@@ -424,7 +378,7 @@
         {
           "alias": "",
           "dsType": "influxdb",
-          "expr": "100 * sum(netdata_system_ram_MB_average{dimension=\"used\",instance=~\"[[host]]\"}) / sum(netdata_system_ram_MB_average{instance=~\"[[host]]\"})",
+          "expr": "100 * sum(netdata_system_ram_MB_average{dimension=\"used\"}) / sum(netdata_system_ram_MB_average)",
           "format": "time_series",
           "groupBy": [
             {
@@ -514,7 +468,7 @@
         "h": 4,
         "w": 3,
         "x": 11,
-        "y": 2
+        "y": 0
       },
       "id": 111,
       "interval": null,
@@ -555,7 +509,7 @@
         {
           "alias": "",
           "dsType": "influxdb",
-          "expr": "sum(netdata_disk_space_GB_average{dimension=\"used\",instance=~\"[[host]]\"}) / (sum(netdata_disk_space_GB_average{instance=~\"[[host]]\"}))",
+          "expr": "sum(netdata_disk_space_GB_average{dimension=\"used\"}) / sum(netdata_disk_space_GB_average)",
           "format": "time_series",
           "groupBy": [
             {
@@ -644,7 +598,7 @@
         "h": 4,
         "w": 3,
         "x": 14,
-        "y": 2
+        "y": 0
       },
       "id": 75,
       "interval": null,
@@ -683,7 +637,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(netdata_openio_score__average{instance=~\"[[host]]\"})",
+          "expr": "avg(aggr:netdata_openio_score:avg_per_service)",
           "format": "time_series",
           "groupBy": [
             {
@@ -735,300 +689,14 @@
       "valueName": "current"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "prometheus",
-      "format": "Kbits",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 18,
-        "y": 2
-      },
-      "id": 25,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "expr": "sum(netdata_net_net_kilobits_persec_average{dimension=\"received\", instance=~\"[[host]]\"}) - sum(netdata_net_net_kilobits_persec_average{dimension=\"sent\", instance=~\"[[host]]\"})\n",
-          "format": "time_series",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "intervalFactor": 1,
-          "measurement": "net",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT sum(\"value\") FROM \"[[DS]]\".\"net\" WHERE \"host\" =~ /^$host$/ AND \"type\" = 'received' AND $timeFilter GROUP BY time([[ds_int]]) fill(null)",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "host",
-              "operator": "=~",
-              "value": "/^$host$/"
-            },
-            {
-              "condition": "AND",
-              "key": "type",
-              "operator": "=",
-              "value": "received"
-            }
-          ]
-        }
-      ],
-      "thresholds": "",
-      "title": "Bandwidth (System)",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "prometheus",
-      "format": "Kbits",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 21,
-        "y": 2
-      },
-      "id": 95,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\"}) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\"})",
-          "format": "time_series",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "intervalFactor": 1,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": "",
-      "title": "Bandwidth (Gateway)",
-      "transparent": false,
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "content": "### Navigation",
-      "gridPos": {
-        "h": 2,
-        "w": 4,
-        "x": 0,
-        "y": 5
-      },
-      "id": 138,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "content": "### Storage",
-      "gridPos": {
-        "h": 2,
-        "w": 6,
-        "x": 5,
-        "y": 6
-      },
-      "id": 139,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "content": "### Internals",
-      "gridPos": {
-        "h": 2,
-        "w": 6,
-        "x": 11,
-        "y": 6
-      },
-      "id": 148,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
       "columns": [],
       "datasource": null,
       "fontSize": "100%",
       "gridPos": {
-        "h": 11,
+        "h": 13,
         "w": 6,
         "x": 18,
-        "y": 6
+        "y": 0
       },
       "id": 147,
       "links": [],
@@ -1062,7 +730,7 @@
           "unit": "short"
         },
         {
-          "alias": "Installed count",
+          "alias": "Count",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1141,7 +809,7 @@
         "h": 13,
         "w": 4,
         "x": 0,
-        "y": 7
+        "y": 3
       },
       "headings": false,
       "id": 118,
@@ -1157,6 +825,21 @@
       "type": "dashlist"
     },
     {
+      "content": "### Storage",
+      "gridPos": {
+        "h": 2,
+        "w": 12,
+        "x": 5,
+        "y": 4
+      },
+      "id": 139,
+      "links": [],
+      "mode": "markdown",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -1166,7 +849,9 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "prometheus",
-      "format": "decgbytes",
+      "decimals": 1,
+      "description": "Total storage used by the application. Does include replication / EC overhead.",
+      "format": "decbytes",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -1178,7 +863,7 @@
         "h": 4,
         "w": 3,
         "x": 5,
-        "y": 8
+        "y": 6
       },
       "id": 24,
       "interval": null,
@@ -1219,7 +904,7 @@
         {
           "alias": "",
           "dsType": "influxdb",
-          "expr": "sum(netdata_disk_space_GB_average{dimension=\"used\",instance=~\"[[host]]\"})",
+          "expr": "sum(avg(label_replace(netdata_openio_byte_used__average, 'dim', '$2', 'dimension', '(%s)[.].*[.]([0-9]*)')) by (dim))",
           "format": "time_series",
           "groupBy": [
             {
@@ -1237,6 +922,7 @@
           ],
           "hide": false,
           "intervalFactor": 1,
+          "legendFormat": "",
           "measurement": "disk_space",
           "orderByTime": "ASC",
           "policy": "default",
@@ -1274,9 +960,99 @@
         }
       ],
       "thresholds": "",
-      "title": "Raw capacity used",
+      "title": "Used storage capacity",
       "type": "singlestat",
-      "valueFontSize": "50%",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "decimals": 1,
+      "description": "Total storage usable by the applications. Doesn't take into account replication / EC overhead",
+      "format": "decbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 8,
+        "y": 6
+      },
+      "id": 150,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(netdata_disk_space_GB_average{dimension=\"used\",instance=~\"[[host]]\"}) + sum(netdata_disk_space_GB_average{dimension=\"avail\",instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "hide": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        },
+        {
+          "expr": "sum(avg(label_replace(netdata_openio_byte_used__average, 'dim', '$2', 'dimension', '(%s)[.].*[.]([0-9]*)')) by (dim)) + sum(avg(label_replace(netdata_openio_byte_avail__average, 'dim', '$2', 'dimension', '(%s)[.].*[.]([0-9]*)')) by (dim))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        }
+      ],
+      "thresholds": "",
+      "title": "Total storage capacity",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "70%",
       "valueMaps": [
         {
           "op": "=",
@@ -1296,6 +1072,8 @@
         "#d44a3a"
       ],
       "datasource": "prometheus",
+      "decimals": 1,
+      "description": "Total amount of actual data stored in OpenIO.",
       "format": "deckbytes",
       "gauge": {
         "maxValue": 100,
@@ -1307,8 +1085,8 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 8,
-        "y": 8
+        "x": 11,
+        "y": 6
       },
       "id": 97,
       "interval": null,
@@ -1342,7 +1120,7 @@
         "fillColor": "#badff4",
         "full": false,
         "lineColor": "rgb(31, 120, 193)",
-        "show": true
+        "show": false
       },
       "tableColumn": "",
       "targets": [
@@ -1386,89 +1164,9 @@
         }
       ],
       "thresholds": "",
-      "title": "Actual data stored",
+      "title": "Stored data",
       "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": null,
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 11,
-        "y": 8
-      },
-      "id": 109,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "#badff4",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(netdata_beanstalk_jobs_jobs_average{instance=~\"[[host]]\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Queue Events",
-      "type": "singlestat",
-      "valueFontSize": "50%",
+      "valueFontSize": "70%",
       "valueMaps": [
         {
           "op": "=",
@@ -1488,8 +1186,8 @@
         "#d44a3a"
       ],
       "datasource": "prometheus",
-      "decimals": 1,
-      "format": "ms",
+      "description": "Total number of objects in storage. Objects uploaded using MPU (Multipart Upload) may result in multiple objects created in OpenIO.",
+      "format": "short",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -1501,231 +1199,7 @@
         "h": 4,
         "w": 3,
         "x": 14,
-        "y": 8
-      },
-      "id": 91,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "#badff4",
-        "full": false,
-        "lineColor": "#5195ce",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", chart2=~\".*.oioswift\", instance=~\"[[host]]\"})",
-          "format": "time_series",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "intervalFactor": 1,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": "",
-      "title": "Gateway Response time",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "prometheus",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 5,
-        "y": 12
-      },
-      "id": 101,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "#badff4",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(netdata_openio_container_count__average)",
-          "format": "time_series",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "intervalFactor": 1,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": "",
-      "title": "Containers",
-      "type": "singlestat",
-      "valueFontSize": "50%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "prometheus",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 8,
-        "y": 12
+        "y": 6
       },
       "id": 99,
       "interval": null,
@@ -1759,7 +1233,7 @@
         "fillColor": "#badff4",
         "full": false,
         "lineColor": "rgb(31, 120, 193)",
-        "show": true
+        "show": false
       },
       "tableColumn": "",
       "targets": [
@@ -1803,9 +1277,9 @@
         }
       ],
       "thresholds": "",
-      "title": "Objects",
+      "title": "Objects (OpenIO)",
       "type": "singlestat",
-      "valueFontSize": "50%",
+      "valueFontSize": "70%",
       "valueMaps": [
         {
           "op": "=",
@@ -1816,19 +1290,492 @@
       "valueName": "current"
     },
     {
-      "content": "",
+      "content": "### Usage",
       "gridPos": {
-        "h": 5,
+        "h": 2,
         "w": 12,
         "x": 5,
-        "y": 16
+        "y": 10
       },
-      "id": 135,
+      "id": 148,
       "links": [],
       "mode": "markdown",
       "title": "",
       "transparent": true,
       "type": "text"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "prometheus",
+      "decimals": 1,
+      "description": "Total bandwidth as seen by the system.",
+      "format": "Kbits",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 5,
+        "y": 12
+      },
+      "id": 25,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "expr": "sum(netdata_net_net_kilobits_persec_average{dimension=\"received\"}) - sum(netdata_net_net_kilobits_persec_average{dimension=\"sent\"})",
+          "format": "time_series",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "intervalFactor": 1,
+          "measurement": "net",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT sum(\"value\") FROM \"[[DS]]\".\"net\" WHERE \"host\" =~ /^$host$/ AND \"type\" = 'received' AND $timeFilter GROUP BY time([[ds_int]]) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "type",
+              "operator": "=",
+              "value": "received"
+            }
+          ]
+        }
+      ],
+      "thresholds": "",
+      "title": "Bandwidth (System)",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "decimals": 1,
+      "description": "Total bandwidth as seen by the S3/Swift gateway",
+      "format": "bps",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 8,
+        "y": 12
+      },
+      "id": 95,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{dimension=\"received\", chart2=~\".*.oioswift\"}) - sum(aggr:netdata_web_log_bandwidth:sum{dimension=\"sent\", chart2=~\".*.oioswift\"})",
+          "format": "time_series",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "intervalFactor": 1,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Bandwidth (Gateway)",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "decimals": 1,
+      "description": "Average response time of the S3 / Swift gateway",
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 11,
+        "y": 12
+      },
+      "id": 91,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "#badff4",
+        "full": false,
+        "lineColor": "#5195ce",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", chart2=~\".*.oioswift\"})",
+          "format": "time_series",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "intervalFactor": 1,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Gateway Response time",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "decimals": 1,
+      "description": "Total number of server (5xx) errors during the past hour",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 14,
+        "y": 12
+      },
+      "id": 151,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "#badff4",
+        "full": false,
+        "lineColor": "#5195ce",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(rate(aggr:netdata_web_log_response_codes:sum{dimension=\"5xx\"}[1h]))",
+          "format": "time_series",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "intervalFactor": 1,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Server errors (1h)",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
     }
   ],
   "refresh": "10s",
@@ -1836,30 +1783,10 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [
-      {
-        "allValue": null,
-        "datasource": "prometheus",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": true,
-        "name": "host",
-        "options": [],
-        "query": "label_values(netdata_system_cpu_percentage_average, instance)",
-        "refresh": 1,
-        "regex": "/.*/",
-        "sort": 2,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      }
-    ]
+    "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {

--- a/files/storage.json
+++ b/files/storage.json
@@ -16,7 +16,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1530202915031,
+  "iteration": 1552580691389,
   "links": [],
   "panels": [
     {
@@ -213,7 +213,7 @@
         {
           "alias": "",
           "dsType": "influxdb",
-          "expr": "sum(netdata_disk_space_GB_average{dimension=\"used\",instance=~\"[[host]]\"}) / (sum(netdata_disk_space_GB_average{instance=~\"[[host]]\"}))",
+          "expr": "100 * sum(netdata_disk_space_GB_average{dimension=\"used\",instance=~\"[[host]]\"}) / (sum(netdata_disk_space_GB_average{instance=~\"[[host]]\"}))",
           "format": "time_series",
           "groupBy": [
             {
@@ -748,7 +748,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1024,7 +1024,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1157,7 +1157,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1166,7 +1166,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1290,7 +1290,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1299,7 +1299,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     }

--- a/files/system.json
+++ b/files/system.json
@@ -16,7 +16,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1530202862192,
+  "iteration": 1552580699335,
   "links": [],
   "panels": [
     {
@@ -42,7 +42,7 @@
         "hideZero": true,
         "max": true,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": true
       },
@@ -529,7 +529,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -657,7 +657,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -780,7 +780,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     group: grafana
     mode: 0644
     backup: true
-  with_items: "{{ grafana_dashboards }}"
+  with_items: "{{ grafana_dashboards + (['filesystem_connector'] if grafana_oiofs_enabled else []) }}"
   notify: restart grafana
 
 - name: Provision - dashboard config


### PR DESCRIPTION
 ##### SUMMARY

Changes have been made to dashboards. Major modifications include:

- New dashboards: diagnostics, filesystem connector
- New graphs: meta2 cache/elections
- Reworked overview
- Reworked health dashboard
- Ymin=0 set on graphs
- Short notations for big numbers (e.g. 1M objects)
- Selectable service filter for OpenIO system

 ##### IMPACT

N/A

 ##### ADDITIONAL INFORMATION

While this change has no impact, it still requires associated metrics to
be gathered. Version 0.4.0 of netdata plugins is thus required to get
all graphs.