### PR TITLE
CHANGE(grafana): Set default dashboard, provision_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ None
 Role Variables
 --------------
 
-| Variable name         | Description                                   | Type    |
-| --------------------- | --------------------------------------------- | ------- |
-| grafana_version       | Version of grafana to use                     | String  |
-| grafana_paths         | Configuration paths used by grafana-server    | Object  |
-| grafana_http          | Host/Port on which grafana listens            | Object  |
-| grafana_auth          | Grafana credentials                           | Object  |
-| grafana_thene         | Theme (dark or light) used by grafana         | String  |
-| grafana_oiofs_enabled | Provision dashboard for filesystem connector  | String  |
-| prometheus_host       | Host on which prometheus source is configured | String  |
-| prometheus_port       | Port on which prometheus source is configured | Integer |
+| Variable name          | Description                                     | Type    |
+| ---------------------- | ----------------------------------------------- | ------- |
+| grafana_version        | Version of grafana to use                       | String  |
+| grafana_paths          | Configuration paths used by grafana-server      | Object  |
+| grafana_http           | Host/Port on which grafana listens              | Object  |
+| grafana_auth           | Grafana credentials                             | Object  |
+| grafana_thene          | Theme (dark or light) used by grafana           | String  |
+| grafana_oiofs_enabled  | Provision dashboard for filesystem connector    | Boolean |
+| grafana_bind_interface | Grafana Network interface to run checks against | String  |
+| grafana_bind_address   | Grafana Network address to run checks against   | Boolean |
+| prometheus_host        | Host on which prometheus source is configured   | String  |
+| prometheus_port        | Port on which prometheus source is configured   | Integer |
 
 
 Tools - Dashboard retriever
@@ -55,7 +57,7 @@ None
 Example Playbook
 ----------------
 
-https://github.com/vdombrovski/ansible-openio-monitoring
+See docker-tests branch
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,12 @@ grafana_http:
   port: 3000
   domain: localhost
 
+grafana_bind_interface: "{{ ansible_default_ipv4.alias }}"
+grafana_bind_address:
+  "{{ hostvars[inventory_hostname]['ansible_' + grafana_bind_interface]['ipv4']['address'] }}"
+
+grafana_provision_only: false
+
 grafana_auth:
   user: admin
   password: admin

--- a/filter_plugins/grafana.py
+++ b/filter_plugins/grafana.py
@@ -1,0 +1,42 @@
+import json
+import urllib2
+from base64 import b64encode
+
+
+class PutRequest(urllib2.Request):
+
+    def __init__(self, *args, **kwargs):
+        return urllib2.Request.__init__(self, *args, **kwargs)
+
+    def get_method(self, *args, **kwargs):
+        return 'PUT'
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'set_default_dashboard': self.set_default_dashboard,
+        }
+
+    def set_default_dashboard(self, target, auth, ip):
+        try:
+            BASE_URL = "%s://%s:%s" % (target['protocol'], ip, target['port'])
+            AUTH = "Basic %s" % b64encode(
+                   "%s:%s" % (auth['user'], auth['password']))
+
+            req = urllib2.Request("%s/api/search" % BASE_URL)
+            req.add_header("Authorization", AUTH)
+
+            data = json.load(urllib2.urlopen(req))
+
+            id = [d['id'] for d in data if d['title'] == 'Overview'][0]
+
+            data = json.dumps(dict(homeDashboardId=id, theme="", timezone=""))
+
+            req = PutRequest("%s/api/user/preferences" % BASE_URL, data=data)
+            req.add_header("Authorization", AUTH)
+            req.add_header("Content-Type", 'application/json')
+            res = json.loads(urllib2.urlopen(req).read())
+            return res["message"]
+        except Exception as e:
+            return "Could not update preferences, %s" % str(e)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,0 @@
----
-# handlers file for ansible-role-grafana
-
-- name: restart grafana
-  service:
-    name: grafana-server
-    state: restarted
-...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,6 @@
     owner: grafana
     group: grafana
     mode: 0644
-  notify: restart grafana
 
 - name: Overwrite systemd unit
   template:
@@ -37,7 +36,6 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart grafana
 
 - name: Reload daemon
   systemd: daemon_reload=yes
@@ -50,7 +48,6 @@
     owner: grafana
     group: grafana
     mode: 0644
-  notify: restart grafana
 
 - name: Provision - dashboards
   copy:
@@ -61,7 +58,6 @@
     mode: 0644
     backup: true
   with_items: "{{ grafana_dashboards + (['filesystem_connector'] if grafana_oiofs_enabled else []) }}"
-  notify: restart grafana
 
 - name: Provision - dashboard config
   template:
@@ -70,11 +66,22 @@
     owner: grafana
     group: grafana
     mode: 0644
-  notify: restart grafana
 
 - name: Start service
   service:
     name: "{{ grafana_service_name }}"
-    state: started
+    state: "{{'started' if grafana_provision_only else 'restarted' }}"
     enabled: true
+
+- name: Ensure the service is started
+  wait_for:
+    host: "{{ grafana_bind_address }}"
+    port: "{{ grafana_http['port'] }}"
+    delay: 10
+
+- name: Set overview as the default dashboard
+  debug:
+    msg: "{{ grafana_http | set_default_dashboard(grafana_auth, grafana_bind_address) }}"
+  when:
+    - not grafana_provision_only
 ...

--- a/templates/openio.yml.j2
+++ b/templates/openio.yml.j2
@@ -6,6 +6,6 @@ providers:
   folder: ''
   type: file
   disableDeletion: false
-  editable: false
+  editable: true
   options:
     path: {{ grafana_paths['dashboards'] }}


### PR DESCRIPTION
 ##### SUMMARY

When logging in, the user would land on a setup page. This change sets
"overview" as the default dashboard instead.

Also, the now mandatory provision mode has been added.

 ##### IMPACT

- grafana_bind_address needs to be properly defined for service check to
work

 ##### ADDITIONAL INFORMATION