### PR TITLE
CHANGE(grafana): Use new metric labels, S3 related tweaks

### DIFF
--- a/files/health.json
+++ b/files/health.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1552499282784,
+  "iteration": 1560861927150,
   "links": [],
   "panels": [
     {
@@ -731,8 +731,8 @@
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "conscience",
-          "value": "conscience"
+          "text": "account",
+          "value": "account"
         }
       },
       "sparkline": {
@@ -744,7 +744,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -814,13 +814,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "zookeeper",
-          "value": "zookeeper"
+          "text": "beanstalkd",
+          "value": "beanstalkd"
         }
       },
       "sparkline": {
@@ -832,7 +832,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -902,13 +902,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "oioproxy",
-          "value": "oioproxy"
+          "text": "conscience",
+          "value": "conscience"
         }
       },
       "sparkline": {
@@ -920,7 +920,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -990,13 +990,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "oioswift",
-          "value": "oioswift"
+          "text": "meta0",
+          "value": "meta0"
         }
       },
       "sparkline": {
@@ -1008,7 +1008,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1078,13 +1078,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "account",
-          "value": "account"
+          "text": "meta1",
+          "value": "meta1"
         }
       },
       "sparkline": {
@@ -1096,7 +1096,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1166,13 +1166,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "redis",
-          "value": "redis"
+          "text": "meta2",
+          "value": "meta2"
         }
       },
       "sparkline": {
@@ -1184,7 +1184,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1254,13 +1254,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "redissentinel",
-          "value": "redissentinel"
+          "text": "oioproxy",
+          "value": "oioproxy"
         }
       },
       "sparkline": {
@@ -1272,7 +1272,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1342,13 +1342,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "beanstalkd",
-          "value": "beanstalkd"
+          "text": "oioswift",
+          "value": "oioswift"
         }
       },
       "sparkline": {
@@ -1360,7 +1360,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1430,13 +1430,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "meta1",
-          "value": "meta1"
+          "text": "rawx",
+          "value": "rawx"
         }
       },
       "sparkline": {
@@ -1448,7 +1448,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1518,13 +1518,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "meta2",
-          "value": "meta2"
+          "text": "rdir",
+          "value": "rdir"
         }
       },
       "sparkline": {
@@ -1536,7 +1536,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1606,13 +1606,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "rawx",
-          "value": "rawx"
+          "text": "redis",
+          "value": "redis"
         }
       },
       "sparkline": {
@@ -1624,7 +1624,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1694,13 +1694,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "rdir",
-          "value": "rdir"
+          "text": "redissentinel",
+          "value": "redissentinel"
         }
       },
       "sparkline": {
@@ -1712,7 +1712,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1782,13 +1782,13 @@
       "rangeMaps": [],
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1552499282784,
+      "repeatIteration": 1560861927150,
       "repeatPanelId": 123,
       "scopedVars": {
         "service": {
           "selected": false,
-          "text": "meta0",
-          "value": "meta0"
+          "text": "zookeeper",
+          "value": "zookeeper"
         }
       },
       "sparkline": {
@@ -1800,7 +1800,95 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (count(probe_success{service=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service=\"[[service]]\"})",
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "50,100",
+      "title": "[[service]]",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "?",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#f29191",
+        "#f2c96d",
+        "#9ac48a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 8
+      },
+      "id": 281,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "minSpan": 3,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [],
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1560861927150,
+      "repeatPanelId": 123,
+      "scopedVars": {
+        "service": {
+          "selected": false,
+          "text": "oiofs",
+          "value": "oiofs"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (count(probe_success{service_type=\"[[service]]\"} == 1) OR vector(0)) / count(probe_success{service_type=\"[[service]]\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1964,6 +2052,51 @@
           "thresholds": [],
           "type": "hidden",
           "unit": "short"
+        },
+        {
+          "alias": "IP:PORT",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "s_instance",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "instance",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "service",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
         }
       ],
       "targets": [
@@ -2118,7 +2251,7 @@
           "unit": "short"
         },
         {
-          "alias": "",
+          "alias": "IP:PORT",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -2129,7 +2262,7 @@
           "decimals": 2,
           "pattern": "s_instance",
           "thresholds": [],
-          "type": "hidden",
+          "type": "number",
           "unit": "short"
         },
         {
@@ -2145,6 +2278,21 @@
           "pattern": "alertstate",
           "preserveFormat": false,
           "sanitize": false,
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "instance",
           "thresholds": [],
           "type": "hidden",
           "unit": "short"
@@ -2179,7 +2327,7 @@
         "multi": false,
         "name": "service",
         "options": [],
-        "query": "label_values(probe_success, service)",
+        "query": "label_values(probe_success, service_type)",
         "refresh": 1,
         "regex": "",
         "sort": 0,

--- a/files/openio_services.json
+++ b/files/openio_services.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1558364805565,
+  "iteration": 1560861966173,
   "links": [],
   "panels": [
     {
@@ -1057,7 +1057,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(netdata_roundtrip_response_time_ms_average, \"request\", \"$1\", \"dimension\", \".*_(.*)\")",
+          "expr": "avg(label_replace(netdata_roundtrip_response_time_ms_average, \"request\", \"$1\", \"dimension\", \".*_(.*)\")) by (request)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{request}}",
@@ -1106,6 +1106,8 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 0,
+      "description": "Irregularities in response codes may indicate service outage",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1127,13 +1129,13 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "percentage": false,
+      "percentage": true,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -1147,7 +1149,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "S3 Response codes",
+      "title": "S3 Response code distribution",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1163,8 +1165,9 @@
       },
       "yaxes": [
         {
+          "decimals": null,
           "format": "short",
-          "label": null,
+          "label": "",
           "logBase": 1,
           "max": null,
           "min": "0",
@@ -1176,7 +1179,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1186,6 +1189,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "The time it takes to successfully PUT/GET exacty 1 byte of data. Used to measure system responsiveness.",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1217,7 +1221,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(netdata_roundtrip_ttfb_ms_average, \"request\", \"$1\", \"dimension\", \".*_(.*)\")",
+          "expr": "avg(label_replace(netdata_roundtrip_ttfb_ms_average, \"request\", \"$1\", \"dimension\", \".*_(.*)\")) by (request)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{request}}",
@@ -1247,7 +1251,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1688,7 +1692,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\", chart2=~\".*.oioswift\"}) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\", chart2=~\".*.oioswift\"})",
+          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\", type=\"oioswift\"}) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\", type=\"oioswift\"})",
           "format": "time_series",
           "groupBy": [
             {
@@ -1783,7 +1787,7 @@
         {
           "alias": "$tag_namespace: $tag_servicetype",
           "dsType": "influxdb",
-          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\"}) by (chart2) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\"}) by (chart2)",
+          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"received\"}) by (type) - sum(aggr:netdata_web_log_bandwidth:sum{instance=~\"[[host]]\", dimension=\"sent\"}) by (type)",
           "format": "time_series",
           "groupBy": [
             {
@@ -1806,7 +1810,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}}",
+          "legendFormat": "{{type}}",
           "measurement": "openio_log_bandwidth",
           "orderByTime": "ASC",
           "policy": "default",
@@ -1941,7 +1945,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", chart2=~\".*.oioswift\", instance=~\"[[host]]\"})",
+          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", type=\"oioswift\", instance=~\"[[host]]\"})",
           "format": "time_series",
           "groupBy": [
             {
@@ -1980,7 +1984,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Gateway response time",
+      "title": "Average Gateway response time",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -2035,7 +2039,7 @@
         {
           "alias": "$tag_namespace: $tag_servicetype: $tag_type",
           "dsType": "influxdb",
-          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", instance=~\"[[host]]\"}) by (chart2, dimension)",
+          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", instance=~\"[[host]]\"}) by (type)",
           "format": "time_series",
           "groupBy": [
             {
@@ -2064,7 +2068,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}} {{dimension}}",
+          "legendFormat": "{{type}}",
           "measurement": "openio_log_response_time",
           "orderByTime": "ASC",
           "policy": "default",
@@ -2172,10 +2176,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(aggr:netdata_web_log_response_codes:sum{dimension=~\"4xx|5xx\", instance=~\"[[host]]\"}) by (dimension, chart2)",
+          "expr": "sum(aggr:netdata_web_log_response_codes:sum{dimension=~\"4xx|5xx\", instance=~\"[[host]]\"}) by (dimension, type)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}} {{dimension}}",
+          "legendFormat": "{{type}} {{dimension}}",
           "refId": "B"
         }
       ],
@@ -2214,6 +2218,119 @@
           "show": true
         }
       ]
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "decimals": 1,
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 80
+      },
+      "id": 138,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgb(232, 232, 232)",
+        "full": false,
+        "lineColor": "#5195ce",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "max(aggr:netdata_web_log_response_time_ms:sum{dimension=\"max\", type=\"oioswift\", instance=~\"[[host]]\"})",
+          "format": "time_series",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "intervalFactor": 1,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Max Gateway response time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
     },
     {
       "aliasColors": {},
@@ -2258,7 +2375,7 @@
         {
           "alias": "$tag_namespace: $tag_servicetype: $tag_type",
           "dsType": "influxdb",
-          "expr": "sum(aggr:netdata_web_log_response_codes:sum{instance=~\"[[host]]\"}) by (dimension, chart2)",
+          "expr": "sum(aggr:netdata_web_log_response_codes:sum{instance=~\"[[host]]\"}) by (dimension, type)",
           "format": "time_series",
           "groupBy": [
             {
@@ -2288,7 +2405,7 @@
           ],
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}} {{dimension}}",
+          "legendFormat": "{{type}} {{dimension}}",
           "measurement": "openio_log_response_codes",
           "orderByTime": "ASC",
           "policy": "default",
@@ -2338,6 +2455,7 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "ops",
           "label": null,
           "logBase": 1,
@@ -2398,7 +2516,7 @@
         {
           "alias": "$tag_namespace: $tag_servicetype: $tag_type",
           "dsType": "influxdb",
-          "expr": "sum(aggr:netdata_web_log_http_request_methods:sum{instance=~\"[[host]]\"}) by (chart2, dimension)",
+          "expr": "sum(aggr:netdata_web_log_http_request_methods:sum{instance=~\"[[host]]\"}) by (type, dimension)",
           "format": "time_series",
           "groupBy": [
             {
@@ -2427,7 +2545,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}} {{dimension}}",
+          "legendFormat": "{{type}} {{dimension}}",
           "measurement": "openio_log_http_method",
           "orderByTime": "ASC",
           "policy": "default",

--- a/files/overview.json
+++ b/files/overview.json
@@ -1490,7 +1490,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{dimension=\"received\", chart2=~\".*.oioswift\"}) - sum(aggr:netdata_web_log_bandwidth:sum{dimension=\"sent\", chart2=~\".*.oioswift\"})",
+          "expr": "sum(aggr:netdata_web_log_bandwidth:sum{dimension=\"received\", type=\"oioswift\"}) - sum(aggr:netdata_web_log_bandwidth:sum{dimension=\"sent\", type=\"oioswift\"})",
           "format": "time_series",
           "groupBy": [
             {
@@ -1605,7 +1605,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", chart2=~\".*.oioswift\"})",
+          "expr": "avg(aggr:netdata_web_log_response_time_ms:sum{dimension=\"avg\", type=\"oioswift\"})",
           "format": "time_series",
           "groupBy": [
             {
@@ -2301,6 +2301,10 @@
   "tags": [],
   "templating": {
     "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
   },
   "timepicker": {
     "hidden": false,


### PR DESCRIPTION
 ##### SUMMARY

Dashboards have been reworked to use new metric labels and new
prometheus aggregation rules.

Minor S3 tweaks introduced to better show behavior:
- Replace Rountrip response codes by a distribution
- Add TTFB description
- Add instantaneous max gateway response time below avg response time

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

Requires: https://github.com/open-io/ansible-role-openio-prometheus/pull/38