### PR TITLE
BUGFIX/MINOR(grafana): Fix wrong include directive

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     - configure
 
 - name: Include per distro tasks
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
 ##### SUMMARY

Currently, the `include` is always played even when the tag doesn't concern it

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION