### PR TITLE
BUGFIX/MINOR(grafana): Drop dependency to jinja 2.8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
     status_code: 200
     body_format: json
     force_basic_auth: true
-    body: "{ \"homeDashboardId\": {{ _dashboards.json | selectattr('title', 'equalto','Overview')
+    body: "{ \"homeDashboardId\": {{ _dashboards.json | selectattr('title', 'match','^Overview$')
 | map(attribute='id') | list | first | int }}, \"timezone\": \"\", \"theme\": \"\"}"
     when:
       - not openio_grafana_provision_only


### PR DESCRIPTION
 ##### SUMMARY

Centos 7 doesn't provide jinja 2.8.
This change allows to install grafana without `pip install -U jinja2`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
[root@e1fcb850ee3d sds]# ansible --version
ansible 2.8.4
  config file = /sds/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jun 20 2019, 20:27:34) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]

[root@e1fcb850ee3d sds]# rpm -qa |grep -i jinja
python-jinja2-2.7.2-4.el7.noarch

[root@e1fcb850ee3d sds]# yum repolist
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: centos.mirror.fr.planethoster.net
 * epel: ftp.nluug.nl
 * extras: centos.mirror.fr.planethoster.net
 * updates: mirror.plusserver.com
repo id                         repo name                                                      status
base/7/x86_64                   CentOS-7 - Base                                                10097
epel/x86_64                     Extra Packages for Enterprise Linux 7 - x86_64                 13384
extras/7/x86_64                 CentOS-7 - Extras                                                304
updates/7/x86_64                CentOS-7 - Updates                                               311
repolist: 24096

[root@e1fcb850ee3d sds]# cat /etc/redhat-release
CentOS Linux release 7.6.1810 (Core)
```