### PR TITLE
BUGFIX/MINOR(grafana): Cast list of directories in a `list`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     mode: 0644
     state: directory
   with_items:
-    "{{ openio_grafana_paths.values() }}"
+    "{{ openio_grafana_paths.values() | list }}"
   tags: configure
 
 - name: Configure


### PR DESCRIPTION
 ##### SUMMARY

In Python2, the dict.keys(), dict.values(), and dict.items() methods returns a list.
In Python3, those methods return a dictionary view object.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dictionary-views