### PR TITLE
CHANGE(grafana): Use redis collector metrics

### DIFF
--- a/files/diagnostics.json
+++ b/files/diagnostics.json
@@ -1,5 +1,4 @@
 {
-  "uid": "diagnostics",
   "annotations": {
     "list": [
       {
@@ -255,5 +254,6 @@
     ]
   },
   "timezone": "",
-  "title": "Diagnostics"
+  "title": "Diagnostics",
+  "uid": "diagnostics"
 }

--- a/files/health.json
+++ b/files/health.json
@@ -1,5 +1,4 @@
 {
-  "uid": "health",
   "annotations": {
     "list": [
       {
@@ -2391,5 +2390,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Health"
+  "title": "Health",
+  "uid": "health"
 }

--- a/files/network.json
+++ b/files/network.json
@@ -1,5 +1,4 @@
 {
-  "uid": "network",
   "annotations": {
     "list": [
       {
@@ -1423,5 +1422,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Network"
+  "title": "Network",
+  "uid": "network"
 }

--- a/files/openio_services.json
+++ b/files/openio_services.json
@@ -1,5 +1,4 @@
 {
-  "uid": "openio_services",
   "annotations": {
     "list": [
       {
@@ -16,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1560861966173,
+  "iteration": 1575307267726,
   "links": [],
   "panels": [
     {
@@ -2687,7 +2686,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(netdata_redis_keys_keys_average{instance=~\"[[host]]\"})",
+          "expr": "max(netdata_redis_keys__count_average{instance=~\"[[host]]\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -2744,7 +2743,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(label_replace(netdata_redis_keys_keys_average{instance=~\"[[host]]\"}, \"chart2\", \"$1\", \"chart\", \".*?_(.*).keys\")) by (chart2)",
+          "expr": "max(label_replace(netdata_redis_keys__count_average, 'cluster', '$1', 'family', '.*:(\\\\d+)')) by (cluster)",
           "format": "time_series",
           "groupBy": [
             {
@@ -2761,7 +2760,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}}",
+          "legendFormat": "cluster {{cluster}}",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -2856,7 +2855,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(label_replace(netdata_redis_operations_operations_persec_average{instance=~\"[[host]]\"}, \"chart2\", \"$1\", \"chart\", \".*?_(.*).operations\")) by (chart2)\n",
+          "expr": "sum(netdata_redis_ops_ops_average) by (family)",
           "format": "time_series",
           "groupBy": [
             {
@@ -2873,7 +2872,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}}",
+          "legendFormat": "{{family}}",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -2992,7 +2991,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(netdata_redis_hit_rate_percent_average{instance=~\"[[host]]\"})",
+          "expr": "100 * sum(netdata_redis_cache_ops_average{dimension=\"hits\"}) / sum(netdata_redis_cache_ops_average)",
           "format": "time_series",
           "groupBy": [
             {
@@ -3009,6 +3008,7 @@
             }
           ],
           "intervalFactor": 1,
+          "legendFormat": "",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -3080,10 +3080,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(label_replace(netdata_redis_memory_kilobytes_average{dimension=\"total\",instance=~\"[[host]]\"}, \"chart2\", \"$1\", \"chart\", \"redis_(.*?).memory\")) by (chart2)",
+          "expr": "netdata_redis_memory_bytes_average{dimension=\"total\", instance=~\"[[host]]\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}}",
+          "legendFormat": "{{family}}",
           "refId": "A"
         }
       ],
@@ -3106,7 +3106,7 @@
       },
       "yaxes": [
         {
-          "format": "deckbytes",
+          "format": "decbytes",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -3160,10 +3160,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(label_replace(netdata_redis_net_kilobits_persec_average{instance=~\"[[host]]\", dimension=\"in\"}, \"chart2\", \"$1\", \"chart\", \"redis_(.*?).net\")) by (chart2)\n- sum(label_replace(netdata_redis_net_kilobits_persec_average{instance=~\"[[host]]\", dimension=\"out\"}, \"chart2\", \"$1\", \"chart\", \"redis_(.*?).net\")) by (chart2)\n",
+          "expr": "sum(netdata_redis_net_bytes_average{instance=~\"[[host]]\"}) by (family)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{chart2}}",
+          "legendFormat": "{{family}}",
           "refId": "A"
         }
       ],
@@ -4126,5 +4126,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "OpenIO Services"
+  "title": "OpenIO Services",
+  "uid": "openio_services"
 }

--- a/files/openio_system.json
+++ b/files/openio_system.json
@@ -1,5 +1,4 @@
 {
-  "uid": "openio_system",
   "annotations": {
     "list": [
       {
@@ -1317,5 +1316,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "OpenIO System"
+  "title": "OpenIO System",
+  "uid": "openio_system"
 }

--- a/files/overview.json
+++ b/files/overview.json
@@ -1,5 +1,4 @@
 {
-  "uid": "overview",
   "annotations": {
     "list": [
       {
@@ -2331,5 +2330,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Overview"
+  "title": "Overview",
+  "uid": "overview"
 }

--- a/files/software_version_info.json
+++ b/files/software_version_info.json
@@ -1,5 +1,4 @@
 {
-  "uid": "software_version_info",
   "annotations": {
     "list": [
       {
@@ -179,5 +178,6 @@
     ]
   },
   "timezone": "",
-  "title": "Software version info"
+  "title": "Software version info",
+  "uid": "software_version_info"
 }

--- a/files/storage.json
+++ b/files/storage.json
@@ -1,5 +1,4 @@
 {
-  "uid": "storage",
   "annotations": {
     "list": [
       {
@@ -1360,5 +1359,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Storage"
+  "title": "Storage",
+  "uid": "storage"
 }

--- a/files/system.json
+++ b/files/system.json
@@ -1,5 +1,4 @@
 {
-  "uid": "system",
   "annotations": {
     "list": [
       {
@@ -850,5 +849,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "System"
+  "title": "System",
+  "uid": "system"
 }

--- a/tools/retriever.py
+++ b/tools/retriever.py
@@ -48,7 +48,7 @@ aborting due to warning")
         if 'dashboard' not in data:
             raise Exception('Invalid dashboard format')
         data = data['dashboard']
-        for k in ('id', 'version', 'uid'):
+        for k in ('id', 'version'):
             if k in data:
                 del data[k]
         if 'time' in data:


### PR DESCRIPTION
 ##### SUMMARY

Following the introduction of the redis collector, the metrics
associated to redis have changed. This ensures that the charts use new
metrics to display the same graphs. See
https://github.com/open-io/ansible-role-openio-netdata/pull/66 for more
details

Also, the uid field is persisted in the retriever tool, to stay
compatible with https://github.com/open-io/ansible-role-openio-grafana/commit/1c26344cf9399836cdce0c31eb498b6f9d6185cc. This is responsible for reorganising JSON fields on other dashboards

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION