### PR TITLE
BUGFIX/MINOR(grafana): Fix wrong indentation in `Update preferences`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,8 +140,8 @@
     force_basic_auth: true
     body: "{ \"homeDashboardId\": {{ _dashboards.json | selectattr('title', 'match','^Overview$')
 | map(attribute='id') | list | first | int }}, \"timezone\": \"\", \"theme\": \"\"}"
-    when:
-      - not openio_grafana_provision_only
+  when:
+    - not openio_grafana_provision_only
   tags: configure
   ignore_errors: "{{ ansible_check_mode }}"
 ...


### PR DESCRIPTION
 ##### SUMMARY

There is a wrong yaml indentation on the task `Update preferences`
This indentation fails with ansible 2.9

note: Missing backport from 19.10 (bd7e72c)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
TASK [grafana : Update preferences] ************************************************************************************************************************************************************************
  systemd:
Thursday 07 November 2019  14:43:07 +0000 (0:00:00.306)       0:00:24.407 *****
fatal: [node00]: FAILED! => changed=false
  msg: 'Unsupported parameters for (uri) module: when Supported parameters include: attributes, backup, body, body_format, client_cert, client_key, content, creates, delimiter, dest, directory_mode, follow, follow_redirects, force, force_basic_auth, group, headers, http_agent, method, mode, owner, regexp, remote_src, removes, return_content, selevel, serole, setype, seuser, src, status_code, timeout, unix_socket, unsafe_writes, url, url_password, url_username, use_proxy, validate_certs'
```