### PR TITLE
BUGFIX/MINOR(grafana): fix directories mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     path: "{{ item }}"
     owner: grafana
     group: grafana
-    mode: 0644
+    mode: 0755
     state: directory
   with_items:
     "{{ openio_grafana_paths.values() }}"


### PR DESCRIPTION
 ##### SUMMARY

Directories were created using mode 0644 instead of 0755 which could
result in some cases to directories without execution bit set. Therefore
grafana would be able to access those directories.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION